### PR TITLE
fix: 修正 appSettingsDir 拼写错误

### DIFF
--- a/services/appsettings.go
+++ b/services/appsettings.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	appSettingsDir  = ".codex-swtich"
+	appSettingsDir  = ".codex-switch"
 	appSettingsFile = "app.json"
 )
 


### PR DESCRIPTION
将 .codex-swtich 改为 .codex-switch，确保应用设置目录名称正确。

🤖 Generated with Claude Code